### PR TITLE
Add fuzzy searching 🔖

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,202 @@
 {
   "name": "seekr",
   "version": "0.1.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "seekr",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "fast-fuzzy": "^1.11.2"
+      },
+      "devDependencies": {
+        "@types/node": "^18.7.5",
+        "terser": "^5.14.2",
+        "typescript": "^4.7.4"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.15",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+      "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "18.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.7.5.tgz",
+      "integrity": "sha512-NcKK6Ts+9LqdHJaW6HQmgr7dT/i3GOHG+pt6BiWv++5SnjtRd4NXeiuN2kA153SjhXPR/AhHIPHPbrsbpUVOww==",
+      "dev": true
+    },
+    "node_modules/acorn": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/fast-fuzzy": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/fast-fuzzy/-/fast-fuzzy-1.11.2.tgz",
+      "integrity": "sha512-H1ct10Pzx+pSO4h7F1uBXET91ay2hy67J1aQZFKL23EXsOoanpwjPNQQoc+NhClKJMmlGGN+0bXhIdFJX70BJw==",
+      "dependencies": {
+        "graphemesplit": "^2.4.1"
+      }
+    },
+    "node_modules/graphemesplit": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/graphemesplit/-/graphemesplit-2.4.4.tgz",
+      "integrity": "sha512-lKrpp1mk1NH26USxC/Asw4OHbhSQf5XfrWZ+CDv/dFVvd1j17kFgMotdJvOesmHkbFX9P9sBfpH8VogxOWLg8w==",
+      "dependencies": {
+        "js-base64": "^3.6.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "node_modules/js-base64": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
+    },
+    "node_modules/pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/terser": {
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
+        "commander": "^2.20.0",
+        "source-map-support": "~0.5.20"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+    },
+    "node_modules/typescript": {
+      "version": "4.7.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
+      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
+    "node_modules/unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "dependencies": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
+    }
+  },
   "dependencies": {
     "@jridgewell/gen-mapping": {
       "version": "0.3.2",
@@ -77,6 +271,33 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true
     },
+    "fast-fuzzy": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/fast-fuzzy/-/fast-fuzzy-1.11.2.tgz",
+      "integrity": "sha512-H1ct10Pzx+pSO4h7F1uBXET91ay2hy67J1aQZFKL23EXsOoanpwjPNQQoc+NhClKJMmlGGN+0bXhIdFJX70BJw==",
+      "requires": {
+        "graphemesplit": "^2.4.1"
+      }
+    },
+    "graphemesplit": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/graphemesplit/-/graphemesplit-2.4.4.tgz",
+      "integrity": "sha512-lKrpp1mk1NH26USxC/Asw4OHbhSQf5XfrWZ+CDv/dFVvd1j17kFgMotdJvOesmHkbFX9P9sBfpH8VogxOWLg8w==",
+      "requires": {
+        "js-base64": "^3.6.0",
+        "unicode-trie": "^2.0.0"
+      }
+    },
+    "js-base64": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.2.tgz",
+      "integrity": "sha512-NnRs6dsyqUXejqk/yv2aiXlAvOs56sLkX6nUdeaNezI5LFFLlsZjOThmwnrcwh5ZZRwZlCMnVAY3CvhIhoVEKQ=="
+    },
+    "pako": {
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+      "integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA=="
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -105,11 +326,25 @@
         "source-map-support": "~0.5.20"
       }
     },
+    "tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw=="
+    },
     "typescript": {
       "version": "4.7.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
       "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
       "dev": true
+    },
+    "unicode-trie": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+      "integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+      "requires": {
+        "pako": "^0.2.5",
+        "tiny-inflate": "^1.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
     "@types/node": "^18.7.5",
     "terser": "^5.14.2",
     "typescript": "^4.7.4"
+  },
+  "dependencies": {
+    "fast-fuzzy": "^1.11.2"
   }
 }

--- a/src/comparators.ts
+++ b/src/comparators.ts
@@ -1,0 +1,161 @@
+import { fuzzy } from 'fast-fuzzy';
+import { searchWithFlags } from './search';
+import { CmpOp, Comparator, Data, DataWithScore, ParseTree, SearchFlags, TokenType } from './types';
+import { clone, getPath } from './utils';
+
+const CmpOperations: Record<CmpOp, (lhs: number | string, rhs: number | string) => boolean> = {
+  [TokenType.GT]: (lhs, rhs) => lhs > rhs,
+  [TokenType.GTE]: (lhs, rhs) => lhs >= rhs,
+  [TokenType.LT]: (lhs, rhs) => lhs < rhs,
+  [TokenType.LTE]: (lhs, rhs) => lhs <= rhs,
+};
+
+/**
+ * Binary comparator only includes records if they match the given query
+ */
+export class BinaryCmp implements Comparator {
+  isAtomSimilar(data: Data, search: string | number, cmpOp?: TokenType) {
+    /**
+     * Checking the presence of cmpOp is important as it may be undefined,
+     * in which case the fallback is equality check.
+     */
+    if (cmpOp && (typeof data === 'string' || typeof data === 'number')) {
+      return CmpOperations[cmpOp](data, search);
+    } else {
+      return data.toString().toLowerCase().includes(search.toString().toLowerCase());
+    }
+  }
+
+  isMatching(
+    record: Data,
+    search: string | number,
+    { path, cmpOp }: Pick<SearchFlags, 'path' | 'cmpOp'>
+  ): boolean {
+    if (typeof record === 'object') {
+      if (path !== undefined) {
+        const selectedField = getPath(record, path);
+
+        /**
+         * Currently it is assumed that the selected result here is atomic
+         * value and not another object.
+         *
+         * Deep search is not supported and the user has to type targeted field selectors for deep objects
+         */
+
+        // if value for the selected field is undefined, don't include in search result
+        return selectedField !== undefined
+          ? this.isAtomSimilar(selectedField, search, cmpOp)
+          : false;
+      } else {
+        // Todo: Deep search? Support Arrays?
+        return Object.values(record).some((value) => this.isAtomSimilar(value, search, cmpOp));
+      }
+    } else {
+      return this.isAtomSimilar(record, search, cmpOp);
+    }
+  }
+
+  and(lhs: ParseTree, rhs: ParseTree, data: DataWithScore[], flags: SearchFlags): DataWithScore[] {
+    const lhsData = searchWithFlags(lhs, data, this, flags);
+    return searchWithFlags(rhs, lhsData, this, flags);
+  }
+
+  or(lhs: ParseTree, rhs: ParseTree, data: DataWithScore[], flags: SearchFlags): DataWithScore[] {
+    const lhsData = searchWithFlags(lhs, data, this, flags);
+    const rhsData = searchWithFlags(rhs, data, this, flags);
+
+    // Set is used to remove duplicate items that matched in both lhs and rhs
+    return [...new Set([...lhsData, ...rhsData])];
+  }
+
+  search(data: DataWithScore[], search: string | number, flags: SearchFlags): DataWithScore[] {
+    return data.filter(({ record }) => {
+      const matched = this.isMatching(record, search, flags);
+      return flags.exclude ? !matched : matched;
+    });
+  }
+}
+
+/**
+ * Fuzzy comparator assigns a quantitative score to each record based on the query.
+ * Higher the score, higher is that record matching the given query
+ *
+ * Unlike Binary comparator, it does not include/exclude records.
+ */
+export class FuzzyCmp implements Comparator {
+  isAtomSimilar(data: Data, search: string | number) {
+    return fuzzy(search.toString(), data.toString().toLowerCase()) * 100;
+  }
+
+  /**
+   * This method does not support comparison operators
+   * as they are not defined for fuzzy searching
+   */
+  getScore(record: Data, search: string | number, { path }: Pick<SearchFlags, 'path'>) {
+    if (typeof record === 'object') {
+      if (path !== undefined) {
+        const selectedField = getPath(record, path);
+
+        /**
+         * Currently it is assumed that the selected result here is atomic
+         * value and not another object.
+         *
+         * Deep search is not supported and the user has to type targeted field selectors for deep objects
+         */
+
+        // if value for the selected field is undefined, return a minimum score to not include it
+        return selectedField !== undefined
+          ? this.isAtomSimilar(selectedField, search)
+          : Number.MIN_SAFE_INTEGER;
+      }
+
+      // Todo: Deep search? Support Arrays?
+      return Object.values(record).reduce<number>(
+        (sum, value) => sum + this.isAtomSimilar(value, search),
+        0
+      );
+    }
+
+    return this.isAtomSimilar(record, search);
+  }
+
+  and(lhs: ParseTree, rhs: ParseTree, data: DataWithScore[], flags: SearchFlags) {
+    const lhsData = searchWithFlags(lhs, clone(data), this, flags);
+    const rhsData = searchWithFlags(rhs, clone(data), this, flags);
+
+    data.forEach(
+      (item, i) =>
+        (item.score =
+          0.6 * Math.min(lhsData[i].score, rhsData[i].score) +
+          0.4 * Math.max(lhsData[i].score, rhsData[i].score))
+    );
+
+    return data;
+  }
+
+  or(lhs: ParseTree, rhs: ParseTree, data: DataWithScore[], flags: SearchFlags) {
+    const lhsData = searchWithFlags(lhs, clone(data), this, flags);
+    const rhsData = searchWithFlags(rhs, clone(data), this, flags);
+
+    data.forEach(
+      (item, i) =>
+        (item.score =
+          0.3 * Math.max(lhsData[i].score, rhsData[i].score) +
+          0.7 * Math.min(lhsData[i].score, rhsData[i].score))
+    );
+
+    return data;
+  }
+
+  search(data: DataWithScore[], search: string | number, flags: SearchFlags): DataWithScore[] {
+    // Comparison operators are not defined for fuzzy search, so fallback to BinaryComparator
+    if (flags.cmpOp) return new BinaryCmp().search(data, search, flags);
+
+    data.forEach((item) => {
+      const score = this.getScore(item.record, search, flags);
+      item.score += flags.exclude ? -score : score;
+    });
+
+    return data;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { LRParser } from './parser';
 import search from './search';
 import table from './table';
-import { Data, ParseTree, Token, TokenType } from './types';
+import { Comparator, Data, ParseTree, Token, TokenType } from './types';
 
 export default class Seekr {
   tree: ParseTree | Token;
@@ -96,11 +96,11 @@ export default class Seekr {
       throw err;
     }
 
-    return (data: Data[]) => search(tree, data);
+    return (data: Data[], comparator?: Comparator) => search(tree, data, comparator);
   }
 
-  search(input: string, data: Data[]) {
-    return this.compile(input)(data);
+  search(input: string, data: Data[], comparator?: Comparator) {
+    return this.compile(input)(data, comparator);
   }
 }
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -9,6 +9,7 @@ export default expandEach<Actions | number>([
     [TokenType.SearchTerm]: { shift: 8 },
     [TokenType.Exclude]: { shift: 9 },
     [TokenType.LParen]: { shift: 12 },
+    [TokenType.RParen]: { reduce: ['S', 'EPSILON'] },
     [TokenType.GT]: { shift: 13 },
     [TokenType.LT]: { shift: 14 },
     [TokenType.GTE]: { shift: 15 },
@@ -35,6 +36,7 @@ export default expandEach<Actions | number>([
     [TokenType.SearchTerm]: { shift: 8 },
     [TokenType.Exclude]: { shift: 9 },
     [TokenType.LParen]: { shift: 12 },
+    [TokenType.RParen]: { reduce: ['S', 'EPSILON'] },
     [TokenType.GT]: { shift: 13 },
     [TokenType.LT]: { shift: 14 },
     [TokenType.GTE]: { shift: 15 },
@@ -109,11 +111,16 @@ export default expandEach<Actions | number>([
     [TokenType.SearchTerm]: { shift: 8 },
     [TokenType.Exclude]: { shift: 9 },
     [TokenType.LParen]: { shift: 12 },
+    [TokenType.RParen]: { reduce: ['S', 'EPSILON'] },
     [TokenType.GT]: { shift: 13 },
     [TokenType.LT]: { shift: 14 },
     [TokenType.GTE]: { shift: 15 },
     [TokenType.LTE]: { shift: 16 },
-    Search: 24,
+    $: {
+      reduce: ['S', 'EPSILON'],
+    },
+    S: 24,
+    Search: 2,
     And: 3,
     Or: 4,
     SearchType: 5,
@@ -143,7 +150,7 @@ export default expandEach<Actions | number>([
     },
   },
   {
-    $: {
+    [`${TokenType.RParen}, $`]: {
       reduce: ['S', 'Search S'],
     },
   },
@@ -229,19 +236,13 @@ export default expandEach<Actions | number>([
   {
     [`${TokenType.And}, ${TokenType.Or}, ${TokenType.SearchTerm}, ${TokenType.Exclude}, ${TokenType.LParen}, ${TokenType.RParen}, ${TokenType.GT}, ${TokenType.LT}, ${TokenType.GTE}, ${TokenType.LTE}, $`]:
       {
-        reduce: [
-          'Group',
-          `${TokenType.SearchTerm} ${TokenType.GroupTerminator} Term`,
-        ],
+        reduce: ['Group', `${TokenType.SearchTerm} ${TokenType.GroupTerminator} Term`],
       },
   },
   {
     [`${TokenType.And}, ${TokenType.Or}, ${TokenType.SearchTerm}, ${TokenType.Exclude}, ${TokenType.LParen}, ${TokenType.RParen}, ${TokenType.GT}, ${TokenType.LT}, ${TokenType.GTE}, ${TokenType.LTE}, $`]:
       {
-        reduce: [
-          'SearchTerm',
-          `${TokenType.LParen} Search ${TokenType.RParen}`,
-        ],
+        reduce: ['SearchTerm', `${TokenType.LParen} S ${TokenType.RParen}`],
       },
   },
 ]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,4 +25,35 @@ export interface Token extends BaseToken {
 
 export type Data = { [key: string]: Data } | string | number | boolean;
 
+export interface DataWithScore {
+  record: Data;
+  score: number;
+}
+
 export type ParseTree = BaseParseTree<Token>;
+
+export interface SearchFlags {
+  path?: string;
+  exclude?: boolean;
+  cmpOp?: CmpOp;
+}
+
+export interface Comparator {
+  /**
+   * Performs `lhs` AND `rhs` operation on `data`
+   * @returns Resulting data after the operation
+   */
+  and(lhs: ParseTree, rhs: ParseTree, data: DataWithScore[], flags: SearchFlags): DataWithScore[];
+
+  /**
+   * Performs `lhs` OR `rhs` operation on `data`
+   * @returns Resulting data after the operation
+   */
+  or(lhs: ParseTree, rhs: ParseTree, data: DataWithScore[], flags: SearchFlags): DataWithScore[];
+
+  /**
+   * Searches `data` with query as `search` and `flags` applied
+   * @returns Resulting data after the operation
+   */
+  search(data: DataWithScore[], search: string | number, flags: SearchFlags): DataWithScore[];
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,14 +4,13 @@
  * @param separator separator that separates multiple keys from the single key
  * @returns expanded object
  */
-export const expand = <T>(object: Record<string, T>, separator = ', ') => {
-  return Object.keys(object).reduce((obj, key) => {
+export const expand = <T>(object: Record<string, T>, separator = ', ') =>
+  Object.keys(object).reduce((obj, key) => {
     key.split(separator).forEach((subkey) => {
       obj[subkey] = object[key];
     });
     return obj;
   }, {} as Record<string, T>);
-};
 
 /**
  * Applies "expand" utility to each object in the array.
@@ -19,12 +18,8 @@ export const expand = <T>(object: Record<string, T>, separator = ', ') => {
  * @param separator
  * @returns array of expanded objects
  */
-export const expandEach = <T>(
-  objects: Record<string, T>[],
-  separator = ', '
-) => {
-  return objects.map((obj) => expand(obj, separator));
-};
+export const expandEach = <T>(objects: Record<string, T>[], separator = ', ') =>
+  objects.map((obj) => expand(obj, separator));
 
 /**
  * Gets a value in the object selected by a dot path
@@ -32,9 +27,15 @@ export const expandEach = <T>(
  * @param path Dot path string
  * @returns Selected field
  */
-export const getPath = <T extends Object>(object: T, path: string) => {
-  return path
+export const getPath = <T extends Object>(object: T, path: string) =>
+  path
     .split('.')
     .filter((key) => key.length)
     .reduce((parent, key) => parent?.[key], object);
-};
+
+/**
+ * Shallow clones each element in the `data` array
+ * @param data Array of elements
+ * @returns A shallow clone of each element in `data`s
+ */
+export const clone = <T>(data: T[]) => data.map((elm) => ({ ...elm }));


### PR DESCRIPTION
### Changes:
- **Extracted out search logic in the form of comparators.**
   Now the library has two parts:
   - **core**: Core methods for query parsing, validation and search.
   - **comparators**: Different comparators for different comparison / matching algorithms.

- **Added `FuzzyCmp` (fuzzy comparator)**
   This comparator performs fuzzy matching and assigns a score to each item instead of hard include / exclude.

- **Added `BinaryCmp` (binary comparator)**
   This comparator performs binary matching and includes / excludes the record based on the query match. This was the default comparison method and now it is available as a comparator.

- **Added implicit AND behaviour within group queries** 🖊
   Earlier the group queries could only have 1 search term or multiple search terms separated by `AND` or `OR` operators.
   Eg. `key:(hello AND world)`.
   Now, it is possible to type multiple search terms separated by space and they will get implicitly `AND`ed.
   Eg. `key:(hello world)` is same as previous query.
   This is a more natural way of writing queries with multiple words and search terms.

- **Group selector nesting** 🪆
   Nested group selectors look like this: `outkey:(inkey1:hello AND inkey2:world)`.  
   Seekr's syntax supported nested group selectors but the functionality was not added. The above query now works and is interpreted as follows:
   - search `outkey.inkey1` for `hello`
   - search `outkey.inkey2` for `world`
   - AND the results of the above two searches.