### PR TITLE
Add support for search indexing 📒

### DIFF
--- a/src/search.ts
+++ b/src/search.ts
@@ -1,8 +1,7 @@
-import { BinaryCmp } from './comparators';
 import {
   CmpOp,
   Comparator,
-  Data,
+  ComparatorWithIndexing,
   DataWithScore,
   ParseTree,
   SearchFlags,
@@ -30,11 +29,11 @@ const And = (
   comparator: Comparator
 ) => (flags.exclude ? comparator.or(lhs, rhs, data, flags) : comparator.and(lhs, rhs, data, flags));
 
-export function searchWithFlags(
+export default function searchWithFlags(
   parseTree: ParseTree | Token,
   data: DataWithScore[],
-  comparator: Comparator,
-  flags: SearchFlags = {}
+  comparator: Comparator | ComparatorWithIndexing,
+  flags: SearchFlags
 ): DataWithScore[] {
   // Base case when a token has been reached
   if (!('body' in parseTree)) {
@@ -117,17 +116,4 @@ export function searchWithFlags(
     default:
       return searchWithFlags(excludeParenthesis(parseTree), data, comparator, flags);
   }
-}
-
-export default function search(
-  compiled: ParseTree | Token,
-  data: Data[],
-  comparator: Comparator = new BinaryCmp()
-) {
-  const scoredData = data.map((record) => ({
-    record,
-    score: 0,
-  }));
-
-  return searchWithFlags(compiled, scoredData, comparator).sort((a, b) => b.score - a.score);
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export interface SearchFlags {
   path?: string;
   exclude?: boolean;
   cmpOp?: CmpOp;
+  indexFields: Set<string>;
 }
 
 export interface Comparator {
@@ -56,4 +57,8 @@ export interface Comparator {
    * @returns Resulting data after the operation
    */
   search(data: DataWithScore[], search: string | number, flags: SearchFlags): DataWithScore[];
+}
+
+export interface ComparatorWithIndexing extends Comparator {
+  addToIndex(path: string, key: string, value: DataWithScore): void;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { SearchFlags } from './types';
+
 /**
  * Expands a terse object with multiple keys sharing same values to a JS compatible object
  * @param object terse object
@@ -39,3 +41,19 @@ export const getPath = <R, T extends Object>(object: T, path: string) =>
  * @returns A shallow clone of each element in `data`s
  */
 export const clone = <T>(data: T[]) => data.map((elm) => ({ ...elm }));
+
+/**
+ * Construct a list of indexes that needs to be searched based on the search flags set.
+ * @param flags Search flags
+ * @returns List of indexes to be searched
+ */
+export const getIndexesToSearch = (flags: SearchFlags): string[] => {
+  /**
+   * If indexedFields is defined and (either path selector is empty or path selector is part of indexedFields),
+   * only then get the indexes to search.
+   */
+  if (flags.indexFields.size && (!flags.path || flags.indexFields.has(flags.path)))
+    return flags.path ? [flags.path] : [...flags.indexFields];
+
+  return [];
+};


### PR DESCRIPTION
**[Search indexes](https://en.wikipedia.org/wiki/Search_engine_indexing)** allow data that gets searched to be **organised in an efficient manner** that **reduces the time taken** to perform the search. Construction of the index generally happens before the search is performed(as construction itself might be costly in both space and time).

The implementation here allows **indexing during instantiation**(which also requires data to be present) which leads to very fast searches on the same data, or **search time indexing** which _may or may not_ lead to fast searches(depends on time it takes to _construct_ the index).

**Indexes are opt-in** and when omitted, Seekr continues to perform **standard search** algorithm on _all_ keys / group selected keys like before.

**NOTE**: Indexing only works on **fields explicitly specified**. If the user does not specify any field to index, Seekr **never assumes** and indexes fields on its own(although this might be a cool optimization if during compilation some group selectors appear multiple times and data gets indexed on it automatically once!).

The indexing **strategy is left to the comparator** and is opt-in as different comparators might index data differently for efficiency.