### PR TITLE
Add `PrefixCmp` comparator 🔦

### DIFF
--- a/src/comparators.ts
+++ b/src/comparators.ts
@@ -11,6 +11,7 @@ import {
   TokenType,
 } from './types';
 import { clone, getIndexesToSearch, getPath } from './utils';
+import { Trie } from './trie';
 
 const CmpOperations: Record<CmpOp, (lhs: number | string, rhs: number | string) => boolean> = {
   [TokenType.GT]: (lhs, rhs) => lhs > rhs,
@@ -196,5 +197,79 @@ export class FuzzyCmp implements ComparatorWithIndexing {
     }
 
     return data;
+  }
+}
+
+export class PrefixCmp implements ComparatorWithIndexing {
+  index: Record<string, Trie<DataWithScore>> = {};
+
+  addToIndex(path: string, key: string, value: DataWithScore) {
+    this.index[path] ??= new Trie();
+
+    key.split(' ').forEach((word) => {
+      this.index[path].add(word, value);
+    });
+  }
+
+  isAtomSimilar(data: Data, search: string | number) {
+    return data
+      .toString()
+      .toLowerCase()
+      .split(' ')
+      .some((word) => word.startsWith(search.toString().toLowerCase()));
+  }
+
+  isMatching(record: Data, search: string | number, { path }: Pick<SearchFlags, 'path'>): boolean {
+    if (typeof record === 'object') {
+      if (path !== undefined) {
+        const selectedField = getPath<Data, Data>(record, path);
+
+        /**
+         * Currently it is assumed that the selected result here is atomic
+         * value and not another object.
+         *
+         * Deep search is not supported and the user has to type targeted field selectors for deep objects
+         */
+
+        // if value for the selected field is undefined, don't include in search result
+        return selectedField !== undefined ? this.isAtomSimilar(selectedField, search) : false;
+      }
+
+      // Todo: Deep search? Support Arrays?
+      return Object.values(record).some((value) => this.isAtomSimilar(value, search));
+    } else {
+      return this.isAtomSimilar(record, search);
+    }
+  }
+
+  and(lhs: ParseTree, rhs: ParseTree, data: DataWithScore[], flags: SearchFlags) {
+    return new BinaryCmp().and(lhs, rhs, data, flags);
+  }
+
+  or(lhs: ParseTree, rhs: ParseTree, data: DataWithScore[], flags: SearchFlags) {
+    return new BinaryCmp().and(lhs, rhs, data, flags);
+  }
+
+  search(data: DataWithScore[], search: string | number, flags: SearchFlags): DataWithScore[] {
+    // Comparison operators are not defined for fuzzy search, so fallback to BinaryComparator
+    if (flags.cmpOp) return new BinaryCmp().search(data, search, flags);
+
+    const indexFields = getIndexesToSearch(flags);
+
+    if (indexFields.length) {
+      /**
+       * Searching through each indexField might cause same record to be returned
+       * multiple times. The result is passed through a set and then converted to
+       * array to remove such duplicates.
+       */
+      return [
+        ...new Set(indexFields.flatMap((field) => this.index[field].searchAll(search as string))),
+      ];
+    } else {
+      return data.filter(({ record }) => {
+        const matched = this.isMatching(record, search, flags);
+        return flags.exclude ? !matched : matched;
+      });
+    }
   }
 }

--- a/src/comparators.ts
+++ b/src/comparators.ts
@@ -247,7 +247,7 @@ export class PrefixCmp implements ComparatorWithIndexing {
   }
 
   or(lhs: ParseTree, rhs: ParseTree, data: DataWithScore[], flags: SearchFlags) {
-    return new BinaryCmp().and(lhs, rhs, data, flags);
+    return new BinaryCmp().or(lhs, rhs, data, flags);
   }
 
   search(data: DataWithScore[], search: string | number, flags: SearchFlags): DataWithScore[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -123,7 +123,7 @@ export default class Seekr {
   private createScoredDataAndIndex(data: Data[]): DataWithScore[] {
     const scoredData = data.map((record) => ({ record, score: 0 }));
 
-    if (this.indexes) {
+    if (this.indexes.size) {
       scoredData.forEach((item) => this.addItemToIndex(item));
     }
 

--- a/src/trie.ts
+++ b/src/trie.ts
@@ -1,0 +1,53 @@
+class Node<T> {
+  nodes: Record<string, Node<T>> = {};
+  end: T[];
+}
+
+/**
+ * Prefix based trie that stores the record(referred to as `value`)
+ * in the array of "end" nodes.
+ */
+export class Trie<T> {
+  trie: Node<T> = new Node();
+
+  add(key: string, value: T) {
+    key = key.toLowerCase();
+
+    let top = this.trie;
+    for (let i = 0; i < key.length; ++i) {
+      const ch = key[i];
+
+      top.nodes[ch] ??= new Node<T>();
+      top = top.nodes[ch];
+    }
+
+    top.end ??= [];
+    top.end.push(value);
+  }
+
+  searchAll(key: string): T[] {
+    key = key.toLowerCase();
+
+    let top = this.trie;
+    for (let i = 0; i < key.length; ++i) {
+      const ch = key[i];
+      if (!top.nodes[ch]) return [];
+
+      top = top.nodes[ch];
+    }
+
+    // DFS through all children nodes as they are part of the result
+    return this.getAllValues(top);
+  }
+
+  private getAllValues(top: Node<T>): T[] {
+    if (top.end) return top.end;
+
+    const result: T[] = [];
+    Object.values(top).forEach((node) => {
+      result.concat(this.getAllValues(node));
+    });
+
+    return result;
+  }
+}


### PR DESCRIPTION
- This comparator performs a prefix search over all the records.
- It is different from `BinaryCmp` as the Binary comparator does not restrict the parts of string matched. Thus `PrefixCmp` only gets a subset of results compared to those computed by `BinaryCmp`.
- While this might be a con, prefix searching is **much faster** than traditional substring search 💪
- It is a **search indexed comparator** and uses tries to perform **extremely fast searches*** over indexed fields ⚡️


<sub>*_around **2ms** for **1 million records**, **no** compound queries._</sub>